### PR TITLE
small fix - preventing from adding together different years when merging

### DIFF
--- a/VVResonances/interactive/modules/submitJobs.py
+++ b/VVResonances/interactive/modules/submitJobs.py
@@ -1428,6 +1428,8 @@ def mergeData(jobname,purity,rootFile,filename,name):
      #if f.find('COND2D') == -1: continue
      if f.find(purity)==-1:
              continue
+     if f.find(filename)==-1:
+         continue
      if f.find('QCD_HT')    != -1: mg_files.append('./res'+jobname+'/'+f)
      elif f.find('QCD_Pt_') != -1: pythia_files.append('./res'+jobname+'/'+f)
      elif f.find('JetHT')   != -1: data_files.append('./res'+jobname+'/'+f)


### PR DESCRIPTION
check which year/period (contained in the filename variable) has been chosen in the makeInputs when merging files, useful since different years are all saved in the same directory