### PR TITLE
speed up for ZprimeZH (and also WH and WZ but not tested for those signals)

### DIFF
--- a/VVResonances/interactive/makeCard.py
+++ b/VVResonances/interactive/makeCard.py
@@ -7,7 +7,7 @@ cmd='combineCards.py '
 
 sf_qcd = 1.0
 
-pseudodata = "ZprimeZH"
+pseudodata = "Vjets"
 outlabel = "sigOnly_ZprimeZH_M2000"
 
 datasets=['2016']#,'2017']
@@ -39,7 +39,8 @@ purities= ['VV_HPLP']#,'VV_HPHP','VH_HPLP','VH_HPHP','VH_LPHP']
 #signals = ["BulkGWW", "BulkGZZ","ZprimeWW","WprimeWZ","VprimeWV","'ZprimeZH'"]
 signals = ["ZprimeZH"]
 
-Tools = DatacardTools(scales,scalesHiggs,vtag_pt_dependence,lumi_unc,vtag_unc,sf_qcd,pseudodata,outlabel)
+doCorrelation = True 
+Tools = DatacardTools(scales,scalesHiggs,vtag_pt_dependence,lumi_unc,vtag_unc,sf_qcd,pseudodata,outlabel,doCorrelation)
 
 for sig in signals:
   cmd ="combineCards.py"

--- a/VVResonances/interactive/makeCard.py
+++ b/VVResonances/interactive/makeCard.py
@@ -8,7 +8,7 @@ cmd='combineCards.py '
 sf_qcd = 1.0
 
 pseudodata = "Vjets"
-outlabel = "sigOnly_ZprimeZH_M2000"
+outlabel = "ZprimeZH"
 
 datasets=['2016']#,'2017']
 
@@ -83,7 +83,6 @@ for sig in signals:
       #if you run on real data or pseudodata
       rootFileData = resultsDir[dataset]+"/JJ_"+p+".root"
       histName="data"
-
       scaleData=1.0 
       if pseudodata=="noVjets":
         print "Using pseudodata without vjets"

--- a/VVResonances/interactive/makeInputs.py
+++ b/VVResonances/interactive/makeInputs.py
@@ -7,8 +7,8 @@ from optparse import OptionParser
 # python makeInputs.py -p 2016 --run "qcdkernel"
 # python makeInputs.py -p 2016 --run "qcdnorm"
 # python makeInputs.py -p 2016 --run "data"
-# python makeInputs_doubleB.py -p 2016 --run "pseudoNOVJETS"
-# python makeInputs_doubleB.py -p 2016 --run "pseudoVJETS"                                                                                                                                                                                                                   
+# python makeInputs.py -p 2016 --run "pseudoNOVJETS"
+# python makeInputs.py -p 2016 --run "pseudoVJETS"                                                                                                                                                                                                                   
 
 parser = OptionParser()
 parser.add_option("-p","--period",dest="period",type="int",default=2016,help="run period")
@@ -302,12 +302,9 @@ if options.run.find("all")!=-1 or options.run.find("sig")!=-1:
     if options.run.find("all")!=-1 or options.run.find("mvv")!=-1:
         print "mjj fit for signal ",signal_inuse
         if signal_inuse.find("H")!=-1:
-            f.makeSignalShapesMVV("JJ_j1"+str(signal_inuse)+"_"+str(period),signaltemplate_inuse,fixParsSigMVV[signal_inuse],"jj_l1_softDrop_mass <= 150 && jj_l1_softDrop_mass > 105 && jj_l2_softDrop_mass <= 105 && jj_l2_softDrop_mass > 65 ")
-            f.makeSignalShapesMVV("JJ_j2"+str(signal_inuse)+"_"+str(period),signaltemplate_inuse,fixParsSigMVV[signal_inuse],"jj_l2_softDrop_mass <= 150 && jj_l2_softDrop_mass > 105 && jj_l1_softDrop_mass <= 105 && jj_l1_softDrop_mass > 65")
+            f.makeSignalShapesMVV("JJ_"+str(signal_inuse)+"_"+str(period),signaltemplate_inuse,fixParsSigMVV[signal_inuse],"( jj_l1_softDrop_mass <= 150 && jj_l1_softDrop_mass > 105 && jj_l2_softDrop_mass <= 105 && jj_l2_softDrop_mass > 65) || (jj_l2_softDrop_mass <= 150 && jj_l2_softDrop_mass > 105 && jj_l1_softDrop_mass <= 105 && jj_l1_softDrop_mass > 65) ")
         elif signal_inuse.find("WZ")!=-1:
-            f.makeSignalShapesMVV("JJ_j1"+str(signal_inuse)+"_"+str(period),signaltemplate_inuse,fixParsSigMVV[signal_inuse],"jj_l1_softDrop_mass <= 105 && jj_l1_softDrop_mass > 85 && jj_l2_softDrop_mass <= 85 && jj_l2_softDrop_mass >= 65 ")
-            f.makeSignalShapesMVV("JJ_j2"+str(signal_inuse)+"_"+str(period),signaltemplate_inuse,fixParsSigMVV[signal_inuse],"jj_l2_softDrop_mass <= 105 && jj_l2_softDrop_mass > 85 && jj_l1_softDrop_mass <= 85 && jj_l1_softDrop_mass >= 65")
-            
+            f.makeSignalShapesMVV("JJ_j1"+str(signal_inuse)+"_"+str(period),signaltemplate_inuse,fixParsSigMVV[signal_inuse],"(jj_l1_softDrop_mass <= 105 && jj_l1_softDrop_mass > 85 && jj_l2_softDrop_mass <= 85 && jj_l2_softDrop_mass >= 65) || (jj_l2_softDrop_mass <= 105 && jj_l2_softDrop_mass > 85 && jj_l1_softDrop_mass <= 85 && jj_l1_softDrop_mass >= 65)")
         else:
             f.makeSignalShapesMVV("JJ_"+str(signal_inuse)+"_"+str(period),signaltemplate_inuse,fixParsSigMVV[signal_inuse.replace('VBF_','')])
     

--- a/VVResonances/python/statistics/DataCardMaker.py
+++ b/VVResonances/python/statistics/DataCardMaker.py
@@ -86,6 +86,7 @@ class DataCardMaker:
 
         pdfName="_".join([name,self.tag])
         vvMass = ROOT.RooDoubleCB(pdfName,pdfName,self.w.var(MVV),self.w.function(SCALEVar),self.w.function(SIGMAVar),self.w.function(ALPHA1Var),self.w.function(N1Var),self.w.function(ALPHA2Var),self.w.function(N2Var))
+        vvMass.setStringAttribute("CACHEPARAMINT",MVV+":MJ1:MJ2")
  	getattr(self.w,'import')(vvMass,ROOT.RooFit.RenameVariable(pdfName,pdfName))
         f.close()
 	
@@ -1753,6 +1754,7 @@ class DataCardMaker:
             self.w.var(p).setMin(mini)
             self.w.var(p).setMax(maxi)
             self.w.var(p).setBins(bins)
+            self.w.var(p).setBins(bins,"cache")
         dataHist=ROOT.RooDataHist(name,name,cList,histogram)
 
         getattr(self.w,'import')(dataHist,ROOT.RooFit.RenameVariable(name,name))

--- a/VVResonances/python/statistics/DataCardMaker.py
+++ b/VVResonances/python/statistics/DataCardMaker.py
@@ -30,7 +30,7 @@ class DataCardMaker:
         self.systematics.append({'name':name,'kind':kind,'values':values })
 
 
-    def addMVVSignalParametricShape(self,name,variable,jsonFile,scale ={},resolution={}):
+    def addMVVSignalParametricShape(self,name,variable,jsonFile,scale ={},resolution={},doCorrelation=True):
         self.w.factory("MH[2000]")
         self.w.var("MH").setConstant(1)
        
@@ -63,26 +63,19 @@ class DataCardMaker:
         ALPHA2Var="_".join(["ALPHA2",name,self.tag])
         N2Var="_".join(["N2",name,self.tag])
         N1Var="_".join(["N1",name,self.tag])
-        if name.find("H")!=-1 or name.find("WZ")!=-1:
+        if doCorrelation:
+            print "MVV sigma & mean will be correlated to jet mass"
             self.w.factory("expr::"+SIGMAVar+"('("+info['SIGMA']+")*"+info['corr_sigma']+"*(1+"+resolutionStr+")',{MH,MJ1,MJ2},"+resolutionSysts[0]+")")
             self.w.factory("expr::"+SCALEVar+"('("+info['MEAN']+")*"+info['corr_mean']+"*(1+"+scaleStr+")',{MH,MJ1,MJ2},"+scaleSysts[0]+")")
-            
-            self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=ALPHA2Var,param=info['ALPHA2']))
-            self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=ALPHA1Var,param=info['ALPHA1']))
-            self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=N1Var,param=info['N1']))
-            self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=N2Var,param=info['N2']))  
-        else:    
+        else:
+            print "MVV sigma & mean will NOT be correlated to jet mass"
             self.w.factory("expr::"+SCALEVar+"('("+info['MEAN']+")*(1+"+scaleStr+")',MH,"+','.join(scaleSysts)+")")
             self.w.factory("expr::"+SIGMAVar+"('("+info['SIGMA']+")*(1+"+resolutionStr+")',MH,"+','.join(resolutionSysts)+")")
-            self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=ALPHA1Var,param=info['ALPHA1']))
-            self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=ALPHA2Var,param=info['ALPHA2']))
-            self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=N1Var,param=info['N1']))
-            self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=N2Var,param=info['N2']))     
+        self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=ALPHA2Var,param=info['ALPHA2']))
+        self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=ALPHA1Var,param=info['ALPHA1']))
+        self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=N1Var,param=info['N1']))
+        self.w.factory("expr::{name}('MH*0+{param}',MH)".format(name=N2Var,param=info['N2']))  
                 
-            
-
-        
-        
 
         pdfName="_".join([name,self.tag])
         vvMass = ROOT.RooDoubleCB(pdfName,pdfName,self.w.var(MVV),self.w.function(SCALEVar),self.w.function(SIGMAVar),self.w.function(ALPHA1Var),self.w.function(N1Var),self.w.function(ALPHA2Var),self.w.function(N2Var))
@@ -1335,10 +1328,7 @@ class DataCardMaker:
         print "import summed pdf "+pdfName
         self.w.factory("SUM::{name}(expr::{name2}_ratio1('(1-{f})',{f})*{name1},{f}*{name2})".format(name=pdfName,name1=pdfName1,f=variable,name2=pdfName2))
        
-            
-      
-
-    def conditionalProduct(self,name,pdf1,varName,pdf2,pdf3,tag1="",tag2="",tag3=""):
+    def conditionalProduct(self,name,pdf1,varName,pdf2,tag1="",tag2=""):
         pdfName="_".join([name,self.tag])
 
         if tag1=="":
@@ -1349,12 +1339,8 @@ class DataCardMaker:
             pdfName2="_".join([pdf2,self.tag])
         else:
             pdfName2="_".join([pdf2,tag2])
-        if tag3=="":    
-            pdfName3="_".join([pdf3,self.tag])
-        else:
-            pdfName3="_".join([pdf3,tag3])
-	    
-        self.w.factory("PROD::{name}({name1}|{x},{name2}|{x},{name3})".format(name=pdfName,name1=pdfName1,x=varName,name2=pdfName2,name3=pdfName3))
+
+        self.w.factory("PROD::{name}({name1}|{x},{name2})".format(name=pdfName,name1=pdfName1,x=varName,name2=pdfName2))
         
     def conditionalProduct2(self,name,pdf1,pdf2,pdf3,varName,tag1="",tag2="",tag3=""):
         pdfName="_".join([name,self.tag])


### PR DESCRIPTION
The following features are introduced:
- only one json file is created and used for MVV, reducing the number of parameters in the workspace
- Andreas' caching speed up 
- when creating the datacards it is now possible to disable the correlation of MVV from the jet masses (for speeding up the limits, the impact is small)
- when the correlation are taken into account, a different product of the pdf is done in order to speed up the calculation (thank to Jennifer)  