### PR TITLE
Signal Mvv binning, bug fixes about tagger initialization

### DIFF
--- a/VVResonances/interactive/cuts.py
+++ b/VVResonances/interactive/cuts.py
@@ -152,20 +152,20 @@ class cuts():
             self.LPSF_htag = data['htagLPSF'+self.yeartag]
             self.vtag_pt_dependence = data["vtag_pt_dependence"+self.yeartag]
             
-            self.catVtag['HP1'] = '('+data["tagging_variables_and_wp"]["varl1Wtag"]+'>'+ data["tagging_variables_and_wp"]["l1Wtag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_HP_Wtag"+self.yeartag])+')' 
-            self.catVtag['HP2'] = '('+data["tagging_variables_and_wp"]["varl2Wtag"]+'>'+ data["tagging_variables_and_wp"]["l2Wtag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_HP_Wtag"+self.yeartag])+')' 
-            self.catVtag['LP1'] = '(('+ data["tagging_variables_and_wp"]["varl1Wtag"]+'<'+ data["tagging_variables_and_wp"]["l1Wtag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_HP_Wtag"+self.yeartag]) +')&&('+ data["tagging_variables_and_wp"]["varl1Wtag"] +'>'+ data["tagging_variables_and_wp"]["l1Wtag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_LP_Wtag"+self.yeartag]) +'))' 
-            self.catVtag['LP2'] = '(('+ data["tagging_variables_and_wp"]["varl2Wtag"]+'<'+ data["tagging_variables_and_wp"]["l2Wtag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_HP_Wtag"+self.yeartag]) +')&&('+ data["tagging_variables_and_wp"]["varl2Wtag"] +'>'+ data["tagging_variables_and_wp"]["l2Wtag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_LP_Wtag"+self.yeartag]) +'))'
-            self.catVtag['NP1'] =  '('+data["tagging_variables_and_wp"]["varl1Wtag"] +'<' +data["tagging_variables_and_wp"]["l1Wtag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_LP_Wtag"+self.yeartag]) + ')' 
-            self.catVtag['NP2'] =  '('+data["tagging_variables_and_wp"]["varl2Wtag"] +'<' +data["tagging_variables_and_wp"]["l2Wtag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_LP_Wtag"+self.yeartag]) + ')' 
-            
-            
-            self.catHtag['HP1'] = '('+data["tagging_variables_and_wp"]["varl1Htag"]+'>'+ data["tagging_variables_and_wp"]["l1Htag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_HP_Htag"+self.yeartag])+')' 
-            self.catHtag['HP2'] = '('+data["tagging_variables_and_wp"]["varl2Htag"]+'>'+ data["tagging_variables_and_wp"]["l2Htag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_HP_Htag"+self.yeartag])+')' 
-            self.catHtag['LP1'] = '(('+ data["tagging_variables_and_wp"]["varl1Htag"]+'<'+ data["tagging_variables_and_wp"]["l1Htag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_HP_Htag"+self.yeartag]) +')&&('+ data["tagging_variables_and_wp"]["varl1Htag"] +'>'+ data["tagging_variables_and_wp"]["l1Htag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_LP_Htag"+self.yeartag]) +'))' 
-            self.catHtag['LP2'] = '(('+ data["tagging_variables_and_wp"]["varl2Htag"]+'<'+ data["tagging_variables_and_wp"]["l2Htag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_HP_Htag"+self.yeartag]) +')&&('+ data["tagging_variables_and_wp"]["varl2Htag"] +'>'+ data["tagging_variables_and_wp"]["l2Htag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_LP_Htag"+self.yeartag]) +'))'
-            self.catHtag['NP1'] =  '('+data["tagging_variables_and_wp"]["varl1Htag"] +'<' +data["tagging_variables_and_wp"]["l1Htag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_LP_Htag"+self.yeartag]) + ')' 
-            self.catHtag['NP2'] =  '('+data["tagging_variables_and_wp"]["varl2Htag"] +'<' +data["tagging_variables_and_wp"]["l2Htag"+self.yeartag].replace("XX", data["tagging_variables_and_wp"]["WP_LP_Htag"+self.yeartag]) + ')' 
+            self.catVtag['HP1'] =  '('+ self.varl1Wtag +'>'+ self.WPHPl1Wtag +')'
+            self.catVtag['HP2'] =  '('+ self.varl2Wtag +'>'+ self.WPHPl2Wtag +')'
+            self.catVtag['LP1'] = '(('+ self.varl1Wtag +'<'+ self.WPHPl1Wtag +')&&('+ self.varl1Wtag +'>'+ self.WPLPl1Wtag +'))' 
+            self.catVtag['LP2'] = '(('+ self.varl2Wtag +'<'+ self.WPHPl2Wtag +')&&('+ self.varl2Wtag +'>'+ self.WPLPl2Wtag +'))'
+            self.catVtag['NP1'] =  '('+ self.varl1Wtag +'<'+ self.WPLPl1Wtag +')' 
+            self.catVtag['NP2'] =  '('+ self.varl2Wtag +'<'+ self.WPLPl2Wtag +')' 
+
+            self.catHtag['HP1'] =  '('+ self.varl1Htag +'>'+ self.WPHPl1Htag +')' 
+            self.catHtag['HP2'] =  '('+ self.varl2Htag +'>'+ self.WPHPl2Htag +')' 
+            self.catHtag['LP1'] = '(('+ self.varl1Htag +'<'+ self.WPHPl1Htag +')&&('+ self.varl1Htag +'>'+ self.WPLPl1Htag +'))' 
+            self.catHtag['LP2'] = '(('+ self.varl2Htag +'<'+ self.WPHPl2Htag +')&&('+ self.varl2Htag +'>'+ self.WPLPl2Htag +'))'
+            self.catHtag['NP1'] =  '('+ self.varl1Htag +'<'+ self.WPLPl1Htag +')' 
+            self.catHtag['NP2'] =  '('+ self.varl2Htag +'<'+ self.WPLPl2Htag +')' 
+
             
             selections = ["common","common_VV","common_VBF","NP","res","nonres","resTT","acceptance","acceptanceMJ","acceptanceMVV","acceptanceGEN","looseacceptanceMJ"]
             for sel in selections:

--- a/VVResonances/interactive/init_VV_VH.json
+++ b/VVResonances/interactive/init_VV_VH.json
@@ -88,7 +88,6 @@
     "l1Htag17" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_17",
     "l2Htag17" : "jj_l2_DeepBoosted_ZHbbvsQCD__XX_default_17",
     "l1Htag18" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_18",
-    "l2Htag18" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_18",
     "l2Htag18" : "jj_l2_DeepBoosted_ZHbbvsQCD__XX_default_18",
     "l1Htag161718" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_161718",
     "l2Htag161718" : "jj_l2_DeepBoosted_ZHbbvsQCD__XX_default_161718",

--- a/VVResonances/interactive/init_VV_VH.json
+++ b/VVResonances/interactive/init_VV_VH.json
@@ -1,11 +1,14 @@
 {
-    "lumi16" : 35900.0,
-    "lumi17" : 41367.0,
-    "lumi18" : 59690.0,
+    "_comment": "lumis from https://twiki.cern.ch/twiki/bin/viewauth/CMS/TWikiLUM" ,
+    "lumi16" : 35920.0,
+    "lumi17" : 41530.0,
+    "lumi18" : 59740.0,
+    "lumi161718": 137190.0,
     "unc_lumi16": 1.025,
     "unc_lumi17": 1.023,
-    "unc_lumi18": 1.0,
-    
+    "unc_lumi18": 1.025,
+    "unc_lumi161718": 1.018,
+
     "HPSF16" :  0.937,
     "LPSF16" :  1.006,
     "HPSF17" :  0.955,
@@ -81,11 +84,15 @@
     "varl1Htag": "jj_l1_DeepBoosted_ZHbbvsQCD",
     "varl2Htag": "jj_l2_DeepBoosted_ZHbbvsQCD",
     "l1Htag16" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_16",
-    "l2Htag16" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_16",
+    "l2Htag16" : "jj_l2_DeepBoosted_ZHbbvsQCD__XX_default_16",
     "l1Htag17" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_17",
-    "l2Htag17" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_17",
+    "l2Htag17" : "jj_l2_DeepBoosted_ZHbbvsQCD__XX_default_17",
     "l1Htag18" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_18",
     "l2Htag18" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_18",
+    "l2Htag18" : "jj_l2_DeepBoosted_ZHbbvsQCD__XX_default_18",
+    "l1Htag161718" : "jj_l1_DeepBoosted_ZHbbvsQCD__XX_default_161718",
+    "l2Htag161718" : "jj_l2_DeepBoosted_ZHbbvsQCD__XX_default_161718",
+
     
     "WP_HP_Wtag16" : "0p05",
     "WP_HP_Wtag17" : "0p05",

--- a/VVResonances/scripts/vvMakeSignalMVVShapes.py
+++ b/VVResonances/scripts/vvMakeSignalMVVShapes.py
@@ -234,7 +234,7 @@ for mass in sorted(samples.keys()):
    
     fitter.w.var("MH").setVal(mass)
 
-    fmax=1.5
+    fmax=1.2
     fmin=0.80
     extra_extra_cut = "&& (jj_LV_mass>%f&&jj_LV_mass<%f)"%(fmin*mass,fmax*mass)
 
@@ -243,7 +243,7 @@ for mass in sorted(samples.keys()):
     print " range will be ",setminMX," - ",setmaxMX
     print "options.binsMVV ",options.binsMVV
     ndiv=1000
-    binning= truncate(getBinning(options.binsMVV,setminMX,setmaxMX,ndiv),fmin*mass,1.2*mass)    
+    binning= truncate(getBinning(options.binsMVV,setminMX,setmaxMX,ndiv),fmin*mass,fmax*mass)    
     
     print "----------------------------------------"
     print binning

--- a/VVResonances/scripts/vvMakeSignalMVVShapes.py
+++ b/VVResonances/scripts/vvMakeSignalMVVShapes.py
@@ -30,7 +30,6 @@ def getBinning(binsMVV,minx,maxx,bins):
         s = binsMVV.split(",")
         for w in s:
             l.append(int(w))
-    print " binning not truncated  ",l
     return l
 
 def truncate(binning,mmin,mmax):

--- a/VVResonances/scripts/vvMakeSignalMVVShapes.py
+++ b/VVResonances/scripts/vvMakeSignalMVVShapes.py
@@ -30,6 +30,7 @@ def getBinning(binsMVV,minx,maxx,bins):
         s = binsMVV.split(",")
         for w in s:
             l.append(int(w))
+    print " binning not truncated  ",l
     return l
 
 def truncate(binning,mmin,mmax):
@@ -233,8 +234,16 @@ for mass in sorted(samples.keys()):
    
     fitter.w.var("MH").setVal(mass)
 
-    extra_extra_cut = "&& (jj_LV_mass>%f&&jj_LV_mass<%f)"%(0.8*mass,1.1*mass)
-    binning= truncate(getBinning(options.binsMVV,min(options.minMX,options.min),options.maxMX,500),0.80*mass,1.2*mass)    
+    fmax=1.5
+    fmin=0.80
+    extra_extra_cut = "&& (jj_LV_mass>%f&&jj_LV_mass<%f)"%(fmin*mass,fmax*mass)
+
+    setmaxMX= options.maxMX*fmax
+    setminMX=min(options.minMX,options.min)
+    print " range will be ",setminMX," - ",setmaxMX
+    print "options.binsMVV ",options.binsMVV
+    ndiv=1000
+    binning= truncate(getBinning(options.binsMVV,setminMX,setmaxMX,ndiv),fmin*mass,1.2*mass)    
     
     print "----------------------------------------"
     print binning

--- a/VVResonances/scripts/vvMakeTTShapes.py
+++ b/VVResonances/scripts/vvMakeTTShapes.py
@@ -217,7 +217,7 @@ def get2DHist(plts, lumi_):
   return histo2D_l1,histo2D_l2,histo2D
 
 def doFit(th1_projY,mjj_mean,mjj_error,N):
-
+  
   fitter=Fitter(['x'])
   fitter.erfexp2Gaus('model','x')
   projY.Rebin(2)

--- a/VVResonances/scripts/vvMakeTTShapes.py
+++ b/VVResonances/scripts/vvMakeTTShapes.py
@@ -217,7 +217,7 @@ def get2DHist(plts, lumi_):
   return histo2D_l1,histo2D_l2,histo2D
 
 def doFit(th1_projY,mjj_mean,mjj_error,N):
-  
+
   fitter=Fitter(['x'])
   fitter.erfexp2Gaus('model','x')
   projY.Rebin(2)


### PR DESCRIPTION
- signal mvv binning and range updated as discussed in the last meeting to have enough bins at low Mx and proper range for every Mx
- updated luminosity and Lumi uncertainties from Twiki
- fixed bug in which l2 variables were referring to l1 branch
- in cuts: using the previously defined taggers and WP for V & H tagging HP/LP instead of redefining them